### PR TITLE
fix param in header, enable basic auth and formparams

### DIFF
--- a/src/canvas/toolbar/RestSettings.vue
+++ b/src/canvas/toolbar/RestSettings.vue
@@ -45,7 +45,10 @@
             
                 <div class="form-group">
                     <label>Auth Token</label>
-                    <input v-model="rest.token" class="form-control" @change="onChange" placeholder="Enter auth token if needed"/>
+                    <div class="MatcToolbarRestAuth">
+                        <DropDownButton :options="authMethods" v-model="rest.authType" style="width:40px"/>
+                        <input v-model="rest.token" class="form-control" @change="onChange" placeholder="Enter auth token if needed"/>
+                    </div>
                 </div>
 
             </div>
@@ -83,6 +86,23 @@
                             @change="onChange">
                         </textarea>
                         -->
+
+                        <p class="MatcHint">
+                            Use the ${databinding} notation to send data from the prototype.
+                        </p>
+                    </div>
+
+                    <div class="form-group" v-if="(rest.method === 'POST' || rest.method === 'PUT') && rest.input.type === 'FORM' " >
+                       
+                        <label>{{ rest.method }} FORM</label>
+                        <Ace 
+                            ref="aceEditor"
+                            v-model="rest.input.template" 
+                            @init="editorInit" 
+                            lang="text" 
+                            theme="chrome" 
+                            width="740" 
+                            height="180"></Ace>
 
                         <p class="MatcHint">
                             Use the ${databinding} notation to send data from the prototype.
@@ -206,6 +226,10 @@ export default {
                 {
                     label: "File",
                     value: "FILE"
+                },
+                {
+                    label: "Form-Encoded",
+                    value: "FORM"
                 }
             ],
             outputTypes: [
@@ -246,7 +270,17 @@ export default {
             testError: '',
             runSuccess: false,
             isDirty: false,
-            uploadedFile: null
+            uploadedFile: null,
+            authMethods: [
+                {
+                    "label": "Bearer",
+                    "value": "Bearer ",
+                },
+                {
+                    "label": "Basic",
+                    "value": "Basic ",
+                }
+            ]
         }
     },
     components: {

--- a/src/style/toolbar_rest.css
+++ b/src/style/toolbar_rest.css
@@ -111,6 +111,29 @@
 }
 
 
+.MatcToolbarRestAuth {
+    display: flex;
+    flex-direction: row;
+    justify-content: stretch;
+}
+
+.MatcToolbarRestAuth input{
+    flex-grow: 1;
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    border-left: 0px;
+}
+
+.MatcToolbarRestAuth .MatcButton{
+    margin-left: 5px;
+    padding-top: 4px;
+}
+
+.MatcToolbarRestAuth .MatcDropDownButtonWidth{
+    margin: 0px;
+    min-width: 110px;
+}
+
 .MatcToolbarRestOutputHeader {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Hi Klaus,

Finally, I send you this pull request for 3 things in rest feature :-):

- Use of params in header:

![image](https://user-images.githubusercontent.com/17884973/88944870-9299dc00-d28d-11ea-9384-fe36512acd9b.png)

- Enable Basic auth, you can choose between Basic a Bearer :-). In the future this could evolve to something more open (for example custom auth header):

![image](https://user-images.githubusercontent.com/17884973/88944952-ac3b2380-d28d-11ea-82bb-72b1dffcff91.png)

- Enable Form-Encoded to post data to rest API. Maybe, in the future, will be good to have some kind of dynamic input form instead of write raw body

![image](https://user-images.githubusercontent.com/17884973/88945300-1eac0380-d28e-11ea-8d89-9e136d6c7bd6.png)

With this improves, for example, in our platform (and many than use oauth authorization) you can simulate a real rest login with oauth security, calling diferent rest APIs with bearer auth that you get with the login call in a secure way. Next steps will be for example to move this into quant-low-code in order to create real secure apps with no code :-).

Take a look and if you find something wrong, let me know and I fix it :-)

Regards Pedro.