### PR TITLE
Fix QUX_USER_ALLOWED_DOMAINS not being read from env

### DIFF
--- a/server/start.js
+++ b/server/start.js
@@ -10,17 +10,17 @@ const helmet = require("helmet");
  */
 const host = '0.0.0.0'
 const assetsRoot = path.resolve(__dirname, '../dist')
-const port = process.env.QUX_HTTP_PORT ?  process.env.QUX_HTTP_PORT * 1 : 8082
-const proxyUrl = process.env.QUX_PROXY_URL ?  process.env.QUX_PROXY_URL : 'https://v1.quant-ux.com'
-const wsUrl = process.env.QUX_WS_URL ?  process.env.QUX_WS_URL : 'wss://ws.quant-ux.com'
-const auth = process.env.QUX_AUTH ?  process.env.QUX_AUTH : 'qux'
-const tos = process.env.QUX_TOS_URL ?  process.env.QUX_TOS_URL : ''
-const keycloak_realm = process.env.QUX_KEYCLOAK_REALM ?  process.env.QUX_KEYCLOAK_REALM : ''
-const keycloak_client = process.env.QUX_KEYCLOAK_CLIENT ?  process.env.QUX_KEYCLOAK_CLIENT : ''
-const keycloak_url = process.env.QUX_KEYCLOAK_URL ?  process.env.QUX_KEYCLOAK_URL : ''
-const sharedLibs = process.env.QUX_SHARED_LIBS ?  process.env.QUX_SHARED_LIBS : ''
+const port = (process.env.QUX_HTTP_PORT * 1) || 8082
+const proxyUrl = process.env.QUX_PROXY_URL || 'https://v1.quant-ux.com'
+const wsUrl = process.env.QUX_WS_URL || 'wss://ws.quant-ux.com'
+const auth = process.env.QUX_AUTH || 'qux'
+const tos = process.env.QUX_TOS_URL || ''
+const keycloak_realm = process.env.QUX_KEYCLOAK_REALM || ''
+const keycloak_client = process.env.QUX_KEYCLOAK_CLIENT || ''
+const keycloak_url = process.env.QUX_KEYCLOAK_URL || ''
+const sharedLibs = process.env.QUX_SHARED_LIBS || ''
 const userAllowSignUp = process.env.QUX_USER_ALLOW_SIGNUP !== 'false'
-const userAllowedDomains = process.env.QUX_USER_ALLOWED_DOMAINS ? QUX_USER_ALLOWED_DOMAINS : '*'
+const userAllowedDomains = process.env.QUX_USER_ALLOWED_DOMAINS || '*'
 
 /**
  *


### PR DESCRIPTION
In server/start.js:23 the QUX_USER_ALLOWED_DOMAINS env was being checked but it was passing an undefined value to the config