### PR TITLE
Change in Redo shortcut

### DIFF
--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,6 +278,13 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
+        } else if (e.ctrlKey + e.shiftKey) {
+          if(!this._inlineEditStarted) {
+            if(k == 90){// ctrl+shift+z
+              this.controller.redo();
+              this.stopEvent(e);
+            }
+          }
         } else if (e.altKey || e.ctrlKey || e.metaKey){
 
           this.logger.log(1,"onKeyPress", "enter > " + k + " > ctrl : " +e.ctrlKey + " > meta :" +(e.ctrlKey || e.metaKey));
@@ -302,10 +309,10 @@ export default {
               this.controller.undo();
               this.stopEvent(e);
             }
-            if(k == 89){// ctrl-y
-              this.controller.redo();
-              this.stopEvent(e);
-            }
+            // if(k == 89){// ctrl-y
+            //   this.controller.redo();
+            //   this.stopEvent(e);
+            // }
 
             if(k == 68){ // ctrl-d
               this.onDuplicate();

--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,9 +278,9 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
-        } else if (e.ctrlKey + e.shiftKey) {
+        } else if (e.ctrlKey + e.shiftKey) { // This is added separately since two modifier keys are used
           if(!this._inlineEditStarted) {
-            if(k == 90){// ctrl+shift+z
+            if(k == 90){// ctrl+shift+z is the shortcut for redo
               this.controller.redo();
               this.stopEvent(e);
             }
@@ -309,11 +309,6 @@ export default {
               this.controller.undo();
               this.stopEvent(e);
             }
-            // if(k == 89){// ctrl-y
-            //   this.controller.redo();
-            //   this.stopEvent(e);
-            // }
-
             if(k == 68){ // ctrl-d
               this.onDuplicate();
               this.stopEvent(e);

--- a/src/canvas/toolbar/mixins/_Render.vue
+++ b/src/canvas/toolbar/mixins/_Render.vue
@@ -403,7 +403,7 @@ export default {
 			this.addTooltip(this.distributeBtn, "Distribute (D) object equally");
 
 			this.addTooltip(this.undo, "Undo (CTRL+Z)");
-			this.addTooltip(this.redo, "Redo (CTRL+Y)");
+			this.addTooltip(this.redo, "Redo (CTRL+Shift+Z)");
 
 			this.addTooltip(this.copyBtn, "Copy (CTRL+C)");
 			this.addTooltip(this.pasteBtn, "Paste (CTRL+V)");


### PR DESCRIPTION
I have changed the redo shortcut to Ctrl+Shift+Z. Corrected tooltip text and added some explanation.

#113  [41]