### PR TITLE
Added overflow auto to Icon tab in Widgets

### DIFF
--- a/src/style/toolbar/toolbar.css
+++ b/src/style/toolbar/toolbar.css
@@ -648,6 +648,7 @@
 .MatcDateSectionIconCntr{
 	width: 100%;
 	height: 450px;
+	overflow: auto;
 }
 
 .MatcDateSectionIconCntr table{


### PR DESCRIPTION
This change fixes overflow issue within the widget's icons tab.