### PR TITLE
New Keyboard shortcuts for layer order

### DIFF
--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,21 +278,7 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
-        } else if(k == 219)  { // [ : to send layer backward
-          if(!this._inlineEditStarted){
-            if(this.toolbar){
-              this.stopEvent(e);
-              this.toolbar.onToolWidgetLayer("backward");
-            }
-          }
-        } else if(k == 221) { // ] : to send layer forward
-          if(!this._inlineEditStarted) {  
-            if(this.toolbar){
-              this.stopEvent(e);
-              this.toolbar.onToolWidgetLayer("forward");
-            }
-          }
-        }
+        } 
  else if (e.altKey || e.ctrlKey || e.metaKey){
 
           this.logger.log(1,"onKeyPress", "enter > " + k + " > ctrl : " +e.ctrlKey + " > meta :" +(e.ctrlKey || e.metaKey));
@@ -345,6 +331,18 @@ export default {
             if(k == 71){ // ctrl-g
               this.onGroup();
               this.stopEvent(e);
+            }
+            if(k == 221) { // ] : to send layer forward  
+              if(this.toolbar){
+                this.stopEvent(e);
+                this.toolbar.onToolWidgetLayer("forward");
+              }
+            }
+            if(k == 219)  { // [ : to send layer backward
+              if(this.toolbar){
+                this.stopEvent(e);
+                this.toolbar.onToolWidgetLayer("backward");
+              }  
             }
           }
 

--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,7 +278,22 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
-        } else if (e.altKey || e.ctrlKey || e.metaKey){
+        } else if(k == 219)  { // [ : to send layer backward
+          if(!this._inlineEditStarted){
+            if(this.toolbar){
+              this.stopEvent(e);
+              this.toolbar.onToolWidgetLayer("backward");
+            }
+          }
+        } else if(k == 221) { // ] : to send layer forward
+          if(!this._inlineEditStarted) {  
+            if(this.toolbar){
+              this.stopEvent(e);
+              this.toolbar.onToolWidgetLayer("forward");
+            }
+          }
+        }
+ else if (e.altKey || e.ctrlKey || e.metaKey){
 
           this.logger.log(1,"onKeyPress", "enter > " + k + " > ctrl : " +e.ctrlKey + " > meta :" +(e.ctrlKey || e.metaKey));
 

--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,13 +278,6 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
-        } else if (e.ctrlKey + e.shiftKey) { // This is added separately since two modifier keys are used
-          if(!this._inlineEditStarted) {
-            if(k == 90){// ctrl+shift+z is the shortcut for redo
-              this.controller.redo();
-              this.stopEvent(e);
-            }
-          }
         } else if(k == 219)  { // [ : to send layer backward
           if(!this._inlineEditStarted){
             if(this.toolbar){

--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,8 +278,7 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
-        } 
- else if (e.altKey || e.ctrlKey || e.metaKey){
+        } else if (e.altKey || e.ctrlKey || e.metaKey){
 
           this.logger.log(1,"onKeyPress", "enter > " + k + " > ctrl : " +e.ctrlKey + " > meta :" +(e.ctrlKey || e.metaKey));
 
@@ -332,12 +331,14 @@ export default {
               this.onGroup();
               this.stopEvent(e);
             }
+            
             if(k == 221) { // ] : to send layer forward  
               if(this.toolbar){
                 this.stopEvent(e);
                 this.toolbar.onToolWidgetLayer("forward");
               }
             }
+
             if(k == 219)  { // [ : to send layer backward
               if(this.toolbar){
                 this.stopEvent(e);

--- a/src/canvas/KeyBoard.vue
+++ b/src/canvas/KeyBoard.vue
@@ -278,6 +278,13 @@ export default {
           if(removed){
             this.stopEvent(e);
           }
+        } else if (e.ctrlKey + e.shiftKey) { // This is added separately since two modifier keys are used
+          if(!this._inlineEditStarted) {
+            if(k == 90){// ctrl+shift+z is the shortcut for redo
+              this.controller.redo();
+              this.stopEvent(e);
+            }
+          }
         } else if(k == 219)  { // [ : to send layer backward
           if(!this._inlineEditStarted){
             if(this.toolbar){

--- a/src/canvas/toolbar/Toolbar.vue
+++ b/src/canvas/toolbar/Toolbar.vue
@@ -1481,7 +1481,8 @@ export default {
 				    	}
 				    	break;
 				    case "forward":
-				    	for(let i=0;i< selection.length; i++){
+						console.log("oldValues:", selection.length);
+						for(let i=0;i< selection.length; i++){
 				    		let id =selection[i];
 				    		oldValues[id]+=1.1; // we add a little more than one, to make sure we do not collide with other
 				    	}
@@ -1520,6 +1521,7 @@ export default {
 				 * zero, not more than one step between layers
 				 */
 				const newValues = this.getNormalizeWidgetZValues(oldValues);
+				console.log("newValues:", newValues);
 				this.controller.setWidgetLayers(newValues);
 			}
 		},

--- a/src/canvas/toolbar/Toolbar.vue
+++ b/src/canvas/toolbar/Toolbar.vue
@@ -1481,7 +1481,6 @@ export default {
 				    	}
 				    	break;
 				    case "forward":
-						console.log("oldValues:", selection.length);
 						for(let i=0;i< selection.length; i++){
 				    		let id =selection[i];
 				    		oldValues[id]+=1.1; // we add a little more than one, to make sure we do not collide with other
@@ -1521,7 +1520,6 @@ export default {
 				 * zero, not more than one step between layers
 				 */
 				const newValues = this.getNormalizeWidgetZValues(oldValues);
-				console.log("newValues:", newValues);
 				this.controller.setWidgetLayers(newValues);
 			}
 		},

--- a/src/canvas/toolbar/mixins/_Dialogs.vue
+++ b/src/canvas/toolbar/mixins/_Dialogs.vue
@@ -246,14 +246,16 @@ export default {
 			this._renderShortCut(db, tbl,"CTRL D", "Duplicate");
 			this._renderShortCut(db, tbl,"CTRL G", "Group / Ungroup");
 			this._renderShortCut(db, tbl,"CTRL &uarr;", "Bring to Front ");
-			this._renderShortCut(db, tbl,"CTRL &darr;", "Send Back");
+			this._renderShortCut(db, tbl,"CTRL &darr;", "Send to Back");
+			this._renderShortCut(db, tbl,"CTRL [", "Send Backward");
+			this._renderShortCut(db, tbl,"CTRL ]", "Bring Forward");
 			this._renderShortCut(db, tbl,"SHIFT CLICK", "Multi Selection");
 			this._renderShortCut(db, tbl,"SHIFT I", "Select Text Color");
 			this._renderShortCut(db, tbl,"CTRL I", "Select Border Color");
 			this._renderShortCut(db, tbl,"I", "Select Background Color");
-			this._renderShortCut(db, tbl,"SPACE", "Move Tool");
-		
+			
 			tbl = db.table().build(right);
+			this._renderShortCut(db, tbl,"SPACE", "Move Tool");
 			this._renderShortCut(db, tbl,"ALT", "Measure Tool");
 			this._renderShortCut(db, tbl,"L", "Create Line");
 			this._renderShortCut(db, tbl,"+", "Zoom In");

--- a/src/canvas/toolbar/mixins/_Render.vue
+++ b/src/canvas/toolbar/mixins/_Render.vue
@@ -209,10 +209,10 @@ export default {
 			css.add(this.layer.domNode, "MatcToolbarDropDownButtonWide");
 			this.layer.updateLabel = false;
 			this.layer.setOptions([
-				{value: "front", label: "Bring to front (CTRL-&uarr;)", icon:"mdi mdi-arrange-bring-to-front"},
-				{value: "forward", label: "Bring forward", icon:"mdi mdi-arrange-bring-forward"},
-				{value: "backward", label: "Send backward", icon:"mdi mdi-arrange-send-backward"},
-				{value: "back", label: "Send back (CTRL-&darr;)", icon:"mdi mdi-arrange-send-to-back"}
+				{value: "front", label: "Bring to front: CTRL + &uarr;", icon:"mdi mdi-arrange-bring-to-front"},
+				{value: "forward", label: "Bring forward: CTRL + ]", icon:"mdi mdi-arrange-bring-forward"},
+				{value: "backward", label: "Send backward: CTRL + [", icon:"mdi mdi-arrange-send-backward"},
+				{value: "back", label: "Send to back: CTRL + &darr;", icon:"mdi mdi-arrange-send-to-back"}
 			]);
 			this.layer.updateSelection = false;
 			this.layer.hideCaret()

--- a/src/style/toolbar/toolbar.css
+++ b/src/style/toolbar/toolbar.css
@@ -1196,7 +1196,7 @@
 
 .MatcToolbarHelpKeyCntr{
 	min-height: 300px;
-	max-height: 600px;
+	max-height: 800px;
 
 }
 


### PR DESCRIPTION
- Added new keyboard shortcut to change layer order. 
- CTRL + [ and CTRL + ] changes layer order backward or forward, by one step. 
- Shortcut is added to render and in keyboard shortcut dialogue. 
- CSS change to avoid scrolling in keyboard shortcut dialogue.