### PR TITLE
Typo - Replace "Conenctor" with "Connector"

### DIFF
--- a/src/nls/en.json
+++ b/src/nls/en.json
@@ -185,7 +185,7 @@
             "hotspot": "Hotspot",
             "logic": "Logic",
             "rest": "Web Service",
-            "or": "Or Conenctor",
+            "or": "Or Connector",
             "ab": "AB Test",
             "script": "Script",
             "vector": "Vector",


### PR DESCRIPTION
Fixed a typo in "Or Connector"