### PR TITLE
QoL - Focus input on databind rule

### DIFF
--- a/src/canvas/toolbar/components/Rule.vue
+++ b/src/canvas/toolbar/components/Rule.vue
@@ -145,6 +145,7 @@ export default {
 				input.setValue(rule.databinding)
 				input.setHints(options);
 				this.tempOwn(on(input, "change", lang.hitch(this, "setDataBinding")));
+				window.requestAnimationFrame(() => input.focus())
 			}
 		},
 


### PR DESCRIPTION
`window.requestAnimationFrame` was required to get focus working, as Vue lifecycle is being circumvented using `DojoWidget.placeAt`