### PR TITLE
Docker - Optimize for development through Docker environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,3 +32,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: runtime-production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,54 @@
-FROM node:16-alpine AS builder
+ARG NODE_VERSION=16
+ARG ALPINE_VERSION=
 
-RUN apk --no-cache add make python3 g++
 
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS production-dependencies
 USER node
 WORKDIR /home/node
 
-COPY --chown=node:node ["package.json", "package-lock.json", "./"]
-RUN npm install
-COPY --chown=node:node . .
+COPY --chown=node:node [".", "./"]
+RUN npm clean-install --omit=dev
+
+
+
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS builder
+USER node
+WORKDIR /home/node
+# RUN apk --no-cache add make python3 g++
+
+COPY --chown=node:node [".", "./"]
+COPY --chown=node:node --from=production-dependencies ["/home/node/node_modules", "node_modules/"]
+
+RUN npm install --include=dev
 RUN npm run build
 
 
 
-FROM node:16-alpine AS deps
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS runtime-production
 
 USER node
 WORKDIR /home/node
 
-COPY --chown=node:node ["package.json", "package-lock.json", "./"]
-RUN npm install --omit=dev
-
-
-
-FROM node:16-alpine AS runner
-
-USER node
-WORKDIR /home/node
-
-COPY --chown=node:node --from=deps ["/home/node/node_modules", "node_modules/"]
+COPY --chown=node:node --from=production-dependencies ["/home/node/node_modules", "node_modules/"]
 COPY --chown=node:node --from=builder ["/home/node/dist", "dist/"]
 COPY --chown=node:node ["server/", "./server"]
 COPY --chown=node:node ["public/", "./public"]
 
 CMD [ "node", "server/start.js" ]
+
+
+
+
+
+
+
+# placed last since if the person targeting runtime-production doesn't have BuildKit installed, it'll build everything until the targeted stage
+# see: https://docs.docker.com/build/building/multi-stage/#differences-between-legacy-builder-and-buildkit
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS runtime-development
+
+USER node
+WORKDIR /home/node
+
+COPY --chown=node:node --from=builder ["/home/node", "./"]
+
+CMD [ "npm", "run", "serve", "--", "--port", "8082" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN npm clean-install --omit=dev
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS builder
 USER node
 WORKDIR /home/node
-# RUN apk --no-cache add make python3 g++
 
 COPY --chown=node:node [".", "./"]
 COPY --chown=node:node --from=production-dependencies ["/home/node/node_modules", "node_modules/"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+
+
+build-prod:
+	docker build --target runtime-production -t quant-ux .
+
+build-dev:
+	docker build --target runtime-development -t quant-ux .
+
+
+up:
+	 docker compose --file docker/docker-compose.yml up
+
+down:
+	 docker compose --file docker/docker-compose.yml down

--- a/README.md
+++ b/README.md
@@ -8,30 +8,55 @@ This repo contains the front end. You can find a working demo at https://quant-u
 ![Alt text](docs/preview.jpg?raw=true "Quant-UX preview")
 
 ## Develpment setup
+### Prerequisite
 ```
 npm install
 ```
 
-### Compiles and hot-reloads for development
+
+### Running Locally on the Host Machine
+
+#### Compiles and hot-reloads for development
 ```
 npm run serve
 ```
 
-### Compiles and minifies for production
+#### Compiles and minifies for production
 ```
 npm run build
 ```
 
-### Run your unit tests
+#### Run your unit tests
 ```
 npm run test:unit
 ```
 
-### Lints and fixes files
+#### Lints and fixes files
 ```
 npm run lint
 ```
 
+### Developing inside a Docker Container
+If you wish to develop by running the service exclusively through Docker, you can build a development image using:
+```bash
+make build-dev
+```
+This will create a Docker Image tagged under `quant-ux`. You can then replace the `klausenschaefersinho/quant-ux` inside your docker-compose file with the newly build `quant-ux` image. Don't forget to mount the source code after replacing the image.
+
+If you're using the provided `docker/docker-compose.yml`, you can simply add the following volume mount to the qux-fe service:
+```yml
+    volumes:
+      - ../src:/home/node/src
+```
+
+You can then make use of the following Makefile rules for quick docker environment setup and teardown:
+```bash
+# docker compose up - targets docker/docker-compose.yml
+make up
+
+# docker compose down - targets docker/docker-compose.yml
+make down
+```
 
 # Installation
 


### PR DESCRIPTION
I do not like running things locally.
As a result, I cleaned up the Dockerfile to have a production and development build steps that can be targeted. The production build is the same as before, while the development build has all development dependencies installed and runs `vue-cli-service serve --port 8082` by default.
While I was at it, I also added some Dockerfile arguments for the node and alpine versions.

Since the Dockerfile now has a production and development build, you have to target the production step explicitly. If you don't, the development build will be produced. To help with that, I added a Makefile with rules for building production and development images. I also added rules for starting and removing the docker environment as defined in the docker/docker-compose.yml file.

I also made sure to update the `docker/build-push-action@v3` workflow action to target the production build step.
See: https://github.com/docker/build-push-action?tab=readme-ov-file#inputs

I wasn't able to test if this `target` field works as expected, so that's something that has to be verified.
I did test the image building and running for both production and development targets.