### PR TITLE
docs: Adding one-click deploy button for RepoCloud.io to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ You can deploy an instance of Quant UX with few clicks and minimal configuration
  
 [![Deploy](https://pub-da36157c854648669813f3f76c526c2b.r2.dev/deploy-on-elestio-black.png)](https://elest.io/open-source/quant-ux)
 
+### RepoCloud.io
+You can deploy an instance of Quant UX with one click on RepoCloud.
+ 
+[![Deploy](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=302)
+
 ## Kubernets
 
 You can find a kubernets configuration here https://github.com/engmsilva/quant-ux-k8s/tree/master/k8s


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud.io with one click.